### PR TITLE
Relabel: idp_initiated_login to idp_initiated_sso

### DIFF
--- a/docs/sso/guides/setup-sso/implement-idp-initiated-sso.mdx
+++ b/docs/sso/guides/setup-sso/implement-idp-initiated-sso.mdx
@@ -62,7 +62,7 @@ const {
   code,
   error,
   error_description,
-  idp_initiated_login,
+  idp_initiated_sso,
   connection_id,
   relay_state,
 } = req.query;
@@ -72,7 +72,7 @@ if (error) {
 }
 
 // check if this is an idp initiated login
-if (idp_initiated_login && idp_initiated_login === 'success') {
+if (idp_initiated_sso && idp_initiated_sso === 'success') {
   // handle idp initiated login
   const authorizationURL = scalekit.getAuthorizationUrl(redirectUri, {
     connectionId: connection_id,

--- a/docs/sso/guides/setup-sso/implement-idp-initiated-sso.mdx
+++ b/docs/sso/guides/setup-sso/implement-idp-initiated-sso.mdx
@@ -45,17 +45,18 @@ Despite the security risks, IdP initiated SSO offers significant convenience to 
 To support it securely, convert the incoming IdP-initiated request to an SP-initiated SSO flow. Refer the below diagram for the recommended workflow from Scalekit.
 
 <figure>
-  ![Scalekit's recommended workflow for IdP initiated SSO](/img/idp_initiated_sso_with_scalekit.png)
+  ![Scalekit's recommended workflow for IdP initiated
+  SSO](/img/idp_initiated_sso_with_scalekit.png)
   <figcaption>Scalekit's recommended workflow for IdP initiated SSO</figcaption>
 </figure>
 
 1. When Scalekit receives an IdP-initiated SSO request from one of your customers, it pings your configured default <SimpleCode>redirect_uri</SimpleCode> with the <SimpleCode>connection_id</SimpleCode> as a request parameter:
 
 ```sh
-https://default_redirect_uri?idp_initiated_login=success&connection_id=conn_12442
+https://default_redirect_uri?idp_initiated_sso=success&connection_id=conn_12442
 ```
 
-2. In your redirect URI handler, check for the <SimpleCode>idp_initiated_login</SimpleCode> parameter. If it's present and set to "success", construct a new authorization URL using the <SimpleCode>connection_id</SimpleCode>:
+2. In your redirect URI handler, check for the <SimpleCode>idp_initiated_sso</SimpleCode> parameter. If it's present and set to "success", construct a new authorization URL using the <SimpleCode>connection_id</SimpleCode>:
 
 ```javascript showLineNumbers title="handle_redirect_url.js"
 const {

--- a/docs/sso/quickstart.mdx
+++ b/docs/sso/quickstart.mdx
@@ -241,7 +241,7 @@ const {
   code,
   error,
   error_description,
-  idp_initiated_login,
+  idp_initiated_sso,
   connection_id,
   relay_state,
 } = req.query;
@@ -251,7 +251,7 @@ if (error) {
 }
 
 // If it is an idp initiated login
-if (idp_initiated_login && idp_initiated_login === 'success') {
+if (idp_initiated_sso && idp_initiated_sso === 'success') {
   const authorizationURL = scalekit.getAuthorizationUrl(redirectUri, {
     connectionId: connection_id,
     ...(relay_state && { state: relay_state }), // optional: pass relay state
@@ -284,7 +284,7 @@ scalekit_client = ScalekitClient(<SCALEKIT_ENVIRONMENT_URL>, <SCALEKIT_CLIENT_ID
 code = request.args.get('code')
 error = request.args.get('error')
 error_description = request.args.get('error_description')
-idp_initiated_login = request.args.get('idp_initiated_login')
+idp_initiated_sso = request.args.get('idp_initiated_sso')
 connection_id = request.args.get('connection_id')
 relay_state = request.args.get('relay_state')
 
@@ -319,7 +319,7 @@ func main() {
   code := r.URL.Query().Get("code")
   error := r.URL.Query().Get("error")
   errorDescription := r.URL.Query().Get("error_description")
-  idpInitiatedLogin := r.URL.Query().Get("idp_initiated_login")
+  idpInitiatedLogin := r.URL.Query().Get("idp_initiated_sso")
   connectionID := r.URL.Query().Get("connection_id")
   relayState := r.URL.Query().Get("relay_state")
 


### PR DESCRIPTION
To make it clear that IdP is initiated login through SSO, we relabeled `idp_initiated_login` to `idp_initiated_sso`. This pull requests updates the necessary documentation updates. 

1. IdP intiated SSO page
2. Quickstart page