### PR TITLE
Reduce top margin for "Environment Setup" H2 heading

### DIFF
--- a/docs/scim/in-product-quickstart.mdx
+++ b/docs/scim/in-product-quickstart.mdx
@@ -41,7 +41,7 @@ SCALEKIT_CLIENT_SECRET = '<SECRET_FROM_SCALEKIT_DASHBOARD>';
 
 ### a. Via API
 
-Refer to the [API reference](/apis) and retrieve users and groups associated with a directory
+Refer to the <a href="/apis" target="_blank" rel="noopener noreferrer">API reference</a> and retrieve users and groups associated with a directory
 
 <CodeWithHeader title="List Users in a Directory">
 
@@ -73,10 +73,10 @@ To receive realtime events from directory providers, create a webhook endpoint f
 
 When the endpoint receives an HTTP POST request with event data from Scalekit, your app can use it to perform the necessary business logic — for example, creating a user account.
 
-Refer to the [API reference](/apis#tag/Webhooks) for the list of all available event types.
+Refer to the <a href="/apis#tag/Webhooks" target="_blank" rel="noopener noreferrer">API reference</a> for the list of all available event types.
 
 ## That's it!
 
 You've successfully automated user provisioning and deprovisioning with SCIM into your application!
 
-See the more detailed guides in [Scalekit Docs](https://docs.scalekit.com)
+See the more detailed guides in <a href="https://docs.scalekit.com" target="_blank" rel="noopener noreferrer">Scalekit Docs</a>

--- a/docs/sso/in-product-quickstart.mdx
+++ b/docs/sso/in-product-quickstart.mdx
@@ -263,4 +263,4 @@ Send users to log in with their organization's identity provider from Your App's
 
 You've successfully integrated SSO into your application!
 
-Now, consider enabling users to authenticate directly [through their identity provider](/sso/guides/setup-sso/implement-idp-initiated-sso) instead of your app's login page, and learn how to [retrieve additional user attributes](/sso/guides/setup-sso/customize-user-attributes) for an enhanced experience.
+Now, consider enabling users to authenticate directly <a href="/sso/guides/setup-sso/implement-idp-initiated-sso" target="_blank" rel="noopener noreferrer">through their identity provider</a> instead of your app's login page, and learn how to <a href="/sso/guides/setup-sso/customize-user-attributes" target="_blank" rel="noopener noreferrer">retrieve additional user attributes</a> for an enhanced experience.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -798,6 +798,10 @@ html[data-inside-iframe='true'] article {
   padding: 0;
 }
 
+h2[id='1-environment-setup'] {
+  margin-top: 0px;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -802,6 +802,10 @@ h2[id='1-environment-setup'] {
   margin-top: 0px;
 }
 
+/* div[id="tabs:cl-6:content-getting-started"] {
+  margin-top: 0px;
+} */
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
- Adjusted `margin-top` for the `<h2>` element with `id="1-environment-setup"` in `src/css/custom.css` to eliminate excessive spacing.

<img width="509" alt="image" src="https://github.com/user-attachments/assets/543981a9-62ab-44a4-a02b-0edf44f2cd35">
