### PR TITLE
Drop the !important usage in Navbar 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -843,14 +843,15 @@ ul.table-of-contents.table-of-contents__left-border:before {
 }
 
 .navbar {
-  padding: 0 var(--ifm-navbar-padding-horizontal);
+  /* padding: 0 var(--ifm-navbar-padding-horizontal); */
   height: 64px;
 
 }
-#__docusaurus > nav {
-  display: flex !important;
+
+/* #__docusaurus > nav {
+  display: flex;
   align-items: center;
-}
+} */
 
 
 .navbar:has(.navbar__secondary) {


### PR DESCRIPTION
- Commented out the padding for the `.navbar` to potentially resolve layout issues.
- Removed `!important` from the `#__docusaurus > nav` display property and commented out the entire block to test layout changes.
- Ensured the navbar maintains a consistent height of 64px.