### PR TITLE
Update webhook endpoint example and add retry policy note

### DIFF
--- a/docs/scim/quickstart.mdx
+++ b/docs/scim/quickstart.mdx
@@ -488,7 +488,7 @@ mux.HandleFunc("POST /webhook", func(w http.ResponseWriter, r *http.Request) {
 </CodeWithHeader>
 
 {/* prettier-ignore */}
-In this example, the endpoint URL is <SimpleCode>https://<span></span>www<span></span>.hero-saas.<span></span>app/api/webhook/user-access</SimpleCode>
+In this example, the endpoint URL is <SimpleCode>https://<span></span>www<span></span>.your-app.<span></span>app/api/webhook/user-access</SimpleCode>
 
 When the endpoint receives an HTTP POST request with event data, it extracts the name and email from
 the payload and calls <SimpleCode>createUserAccount()</SimpleCode> to perform the necessary business
@@ -516,3 +516,9 @@ See [Webhook Events](/apis#tag/Webhooks) for the list of all available event typ
 
 You have now successfully created and registered a webhook endpoint, allowing your app to receive
 real-time events to automate user provisioning.
+
+:::note
+
+Webhook messages are delivered using an exponential backoff retry policy until a successful HTTP 200 or 201 response is received. The retry intervals are: immediately, 5 seconds, 5 minutes, 30 minutes, 2 hours, 5 hours, and then 10 hours for subsequent attempts. This approach ensures reliable delivery while minimizing server load.
+
+:::

--- a/docs/scim/quickstart.mdx
+++ b/docs/scim/quickstart.mdx
@@ -519,6 +519,15 @@ real-time events to automate user provisioning.
 
 :::note
 
-Webhook messages are delivered using an exponential backoff retry policy until a successful HTTP 200 or 201 response is received. The retry intervals are: immediately, 5 seconds, 5 minutes, 30 minutes, 2 hours, 5 hours, and then 10 hours for subsequent attempts. This approach ensures reliable delivery while minimizing server load.
+We attempt to deliver a message using an exponential backoff retry policy until we receive a successful 200/201 response code from your servers.
+Each webhook message is attempted based on the following schedule, where each attempt period is after the previous failed attempt:
 
+- Immediately
+- 5 seconds
+- 5 minutes
+- 30 minutes
+- 2 hours
+- 5 hours
+- 10 hours
+- 10 hours
 :::


### PR DESCRIPTION
- Changed the example endpoint URL to a more generic placeholder.
- Added a note explaining the exponential backoff retry policy for webhook message delivery.