### PR TITLE
Improve PostHog shutdown safety in DocsRating component

### DIFF
--- a/src/components/DocsRating.jsx
+++ b/src/components/DocsRating.jsx
@@ -23,8 +23,12 @@ const DocsRating = ({ label }) => {
 
   useEffect(() => {
     return () => {
-      if (typeof window !== 'undefined') {
-        posthog?.shutdown();
+      if (
+        typeof window !== 'undefined' &&
+        posthog &&
+        typeof posthog.shutdown === 'function'
+      ) {
+        posthog.shutdown();
       }
     };
   }, [posthog]);


### PR DESCRIPTION
Since PostHog is not shutdown properly, docusaurus throws "Page Crashed" errors randomly while navigation. This PR fixes this bug by adding validations.