### PR TITLE
docs: Simplify SSO quickstart page title for improved clarity

### DIFF
--- a/docs/sso/quickstart.mdx
+++ b/docs/sso/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Scalekit SSO Quickstart Guide | Rapid Single Sign-On Integration'
+title: 'Scalekit SSO Quickstart'
 description: "Implement Single Sign-On in your B2B SaaS application swiftly with Scalekit's comprehensive SSO quickstart guide, supporting SAML and OIDC protocols."
 keywords:
   [


### PR DESCRIPTION
The CTA from the home to next SSO quickstart is labelled wrong. This applies fix. 