### PR TITLE
Maintenance updates (v2)

### DIFF
--- a/docs/integrations/social-connections/google.mdx
+++ b/docs/integrations/social-connections/google.mdx
@@ -2,7 +2,6 @@
 pagination_next: null
 pagination_prev: null
 displayed_sidebar: integrationsSidebar
-title: "Scalekit Google Sign-In Guide | Configure Social Authentication"
 description: "Learn how to integrate Google Sign-In with Scalekit, enabling secure social authentication for your users with step-by-step OAuth configuration instructions."
 keywords: ["Google Sign-In", "Social Login", "OAuth 2.0", "Authentication", "User Login", "Google OAuth", "Social Authentication", "Integration Guide"]
 ---

--- a/docs/m2m/api-auth-for-m2m-clients.mdx
+++ b/docs/m2m/api-auth-for-m2m-clients.mdx
@@ -1,7 +1,5 @@
 ---
 displayed_sidebar: m2mSidebar
-pagination_next: null
-pagination_prev: null
 ---
 
 # API authentication for M2M clients

--- a/docs/manage-scalekit/glossary.mdx
+++ b/docs/manage-scalekit/glossary.mdx
@@ -29,6 +29,6 @@ displayed_sidebar: homeSidebar
 
 # Glossary
 
-<Subtitle>Understanding Key Terms for Implementation with Scalekit</Subtitle>
+<Subtitle>Understanding essential terms for implementation with Scalekit</Subtitle>
 
 <GlossaryListing />

--- a/docs/scim/admin-portal.mdx
+++ b/docs/scim/admin-portal.mdx
@@ -1,5 +1,4 @@
 ---
-title: 'SCIM admin portal: Configure user provisioning with Scalekit'
 description:
   "Learn how to empower IT administrators with Scalekit's admin portal for SCIM Provisioning
   configuration. Implement no-code or embedded solutions for seamless directory integration and
@@ -22,6 +21,8 @@ keywords:
     'User synchronization',
     'Access management',
   ]
+pagination_next: null
+pagination_prev: scim/domain-and-theme-customization
 ---
 
 import InstallSDK from '@site/docs/sso/templates/_install-sdk.md';
@@ -54,7 +55,7 @@ Log in to your [Scalekit dashboard](https://app.scalekit.com/).
 
 <figure>![Integrate via shareable link](@site/docs/scim/assets/1-admin-portal.png)</figure>
 
-**Important considerations**
+### Important considerations
 
 - This link is valid for 7 days but can be revoked at any time from the dashboard for security
   purposes.
@@ -161,7 +162,7 @@ attribute of an iframe in your web pages.
 
 </CodeWithHeader>
 
-**Important considerations**
+### Important considerations
 
 1. The generated link is designed for one-time use and expires after 1 minute.
 2. The embedded portal session times out after 6 hours, requiring administrators to complete the

--- a/docs/scim/automatically-assign-roles.mdx
+++ b/docs/scim/automatically-assign-roles.mdx
@@ -25,17 +25,11 @@ keywords: [
 
 <Subtitle>Assign app roles from directory group memberships</Subtitle>
 
-Manually assigning roles to users in your application, such as viewer, member, editor, or admin, can
-be a time-consuming task for administrators, particularly in large enterprises where access needs
-frequently change. Scalekit streamlines this process by allowing administrators to establish
-workflows that automatically update your app about the roles to assign to users.
+Manually assigning roles to users in your application, such as viewer, member, editor, or admin, can be a time-consuming task for administrators, particularly in large enterprises where access needs frequently change. Scalekit streamlines this process by allowing administrators to establish workflows that automatically update your app about the roles to assign to users.
 
 ## Introduction
 
-A common strategy for managing varying access levels is to group users based on their specific
-access requirements. For example, if you are developing an application similar to GitHub with roles
-like maintainer, writer, and viewer, customer administrators can create user groups for each role
-within their directory provider.
+A common strategy that organization administrators use for managing varying access levels is to group users based on their specific access requirements. For example, if you are developing an application similar to GitHub with roles like maintainer, writer, and viewer, customer administrators can create user groups for each role within their directory provider.
 
 <figure>
   ![SCIM user provisioning flow directory to Scalekit to your B2B
@@ -43,11 +37,8 @@ within their directory provider.
   <figcaption>SCIM user provisioning flow directory to Scalekit to your app</figcaption>
 </figure>
 
-Scalekit notifies your application when administrators create groups or add users to them, enabling
-you to take necessary actions such as creating or modifying user roles as directed by the
-organization's administrator. Regardless of the directory provider your customers use, Scalekit
-delivers normalized information, eliminating the need for data transformation across different
-providers.
+Scalekit notifies your application when administrators create groups or add users to them, enabling you to take necessary actions such as creating or modifying user roles as directed by the organization's administrator. Regardless of the directory provider your customers use, Scalekit
+delivers normalized information, eliminating the need for data transformation across different providers. A user can belong to multiple groups and, as a result, may be assigned multiple roles in your application, depending on your role-mapping logic.
 
 ## Enabling group-based role assignment
 
@@ -56,9 +47,9 @@ To enable administrators to map groups to roles in your app:
 1. Go to the Scalekit dashboard
 2. Select "SCIM Provisioning"
 3. Switch to the "Role assignment" tab
-4. Create your app's roles
+4. Register your app's roles
 
-<figure className="width-75">
+<figure>
   ![How Scalekit works](@site/docs/scim/assets/automatically-assign-roles-4.png)
   <figcaption>Registering roles in Scalekit dashboard.</figcaption>
 </figure>

--- a/docs/scim/automatically-assign-roles.mdx
+++ b/docs/scim/automatically-assign-roles.mdx
@@ -19,6 +19,8 @@ keywords: [
     'Directory events',
     'Role configuration',
   ]
+pagination_next: null
+pagination_prev: null
 ---
 
 # Automatic role assignment
@@ -202,9 +204,8 @@ mux.HandleFunc("POST /webhook", func(w http.ResponseWriter, r *http.Request) {
 </Tabs>
 </CodeWithHeader>
 
-See the [User event payload reference](/apis#tag/Webhooks/organization.directory.user_updated) for
-more information about the payload structure.
+See the [User event payload reference](/apis#tag/Webhooks/organization.directory.user_updated) for more information about the payload structure.
 
-By utilizing Scalekit's group-based role assignment feature, you can simplify access management for
-your enterprise customers and ensure that user roles remain synchronized with their directory
-provider.
+## Next steps
+
+Set up [webhook endpoints](/apis#tag/Webhooks) to receive the Directory events and assign roles to users in your applications.

--- a/docs/scim/basics.mdx
+++ b/docs/scim/basics.mdx
@@ -19,6 +19,8 @@ keywords: [
   'Microsoft Entra ID'
 ]
 hide_table_of_contents: true
+pagination_next: null
+pagination_prev: null
 ---
 
 # Basics of SCIM Provisioning

--- a/docs/scim/domain-and-theme-customization.mdx
+++ b/docs/scim/domain-and-theme-customization.mdx
@@ -14,12 +14,14 @@ keywords:
     'Accent color',
     'Favicon',
   ]
+pagination_next: null
+pagination_prev: scim/admin-portal
 ---
 
 # Customize the admin portal
 
 <Subtitle>
-Customize your admin portal UI to align with your brand identity and design preferences```
+Customize your admin portal UI to align with your brand identity and design preferences
 </Subtitle>
 
 Customizing your admin portal ensures that its interface matches your application's brand identity.

--- a/docs/scim/scim-protocol.mdx
+++ b/docs/scim/scim-protocol.mdx
@@ -18,6 +18,8 @@ keywords: [
   'Employee onboarding',
   'Access provisioning'
 ]
+pagination_next: null
+pagination_prev: null
 ---
 
 # SCIM Overview

--- a/docs/scim/webhooks.mdx
+++ b/docs/scim/webhooks.mdx
@@ -18,6 +18,8 @@ keywords: [
     'Directory synchronization',
     'Event types',
   ]
+pagination_next: null
+pagination_prev: null
 ---
 
 # Best practices for webhooks

--- a/docs/sso/quickstart.mdx
+++ b/docs/sso/quickstart.mdx
@@ -14,6 +14,8 @@ keywords:
     'API Integration',
     'Security',
   ]
+pagination_next: sso/test-sso
+pagination_prev: null
 ---
 
 import InstallSDK from '@site/docs/sso/templates/_install-sdk.md';

--- a/docs/sso/social-login.mdx
+++ b/docs/sso/social-login.mdx
@@ -14,6 +14,8 @@ keywords:
     'B2B SaaS security',
     'Identity provider',
   ]
+pagination_next: integrations/social-connections/google
+pagination_prev: null
 ---
 
 import InstallSDK from '@site/docs/sso/templates/_install-sdk.md';
@@ -32,7 +34,7 @@ just a few lines of code.
 
 <figure>
   ![How Scalekit works](@site/docs/sso/assets/single-sign-on/quickstart/scalekit_social.png)
-  <figcaption>Login with social providers via Scalekit</figcaption>
+  <figcaption>Login with social connectors via Scalekit</figcaption>
 </figure>
 
 ## 1. Environment setup
@@ -121,7 +123,7 @@ import { Scalekit } from '@scalekit-sdk/node';
 const scalekit = new Scalekit('<SCALEKIT_ENVIRONMENT_URL>', '<SCALEKIT_CLIENT_ID>', '<SCALEKIT_CLIENT_SECRET>');
 
 const authorizationURL = scalekit.getAuthorizationUrl(redirectUri, {
-  provider: 'microsoft',
+  provider: 'google',
   state: state, // optional
 });
 

--- a/docs/sso/social-login.mdx
+++ b/docs/sso/social-login.mdx
@@ -102,7 +102,7 @@ Construct the authorization URL using the following query parameters:
 https://auth.scalekit.com/authorize?
   client_id=skc_122056050118122349527&
   redirect_uri=https://yourapp.com/auth/callback&
-  provider=microsoft
+  provider=google
 ```
 
 </CodeWithHeader>
@@ -145,7 +145,7 @@ scalekit_client = ScalekitClient(
 
 options = AuthorizationUrlOptions()
 
-options.provider = 'microsoft'
+options.provider = 'google'
 
 authorization_url = scalekit_client.get_authorization_url(
   redirect_uri=<redirect_uri>,
@@ -172,7 +172,7 @@ func main() {
 
   options := scalekitClient.AuthorizationUrlOptions{}
   // Pass the social login provider details while constructing the authorization URL.
-  options.Provider = "microsoft"
+  options.Provider = "google"
 
   authorizationURL := scalekitClient.GetAuthorizationUrl(
     redirectUrl,
@@ -199,7 +199,7 @@ public class Main {
       "<SCALEKIT_CLIENT_SECRET>"
     );
     AuthorizationUrlOptions options = new AuthorizationUrlOptions();
-    options.setProvider("microsoft");
+    options.setProvider("google");
     try {
       // Pass the social login provider details while constructing the authorization URL.
       String url = scalekitClient.authentication().getAuthorizationUrl(redirectUrl, options).toString();

--- a/docs/sso/test-sso.mdx
+++ b/docs/sso/test-sso.mdx
@@ -1,5 +1,4 @@
 ---
-title: "Scalekit SSO Testing Guide | Validate Single Sign-On Integrations"
 description: "Learn how to test your SSO implementation using Scalekit's IdP Simulator and Test Organization, ensuring seamless and secure authentication workflows."
 ---
 


### PR DESCRIPTION
- Removed the title from the Google Sign-In guide to streamline content.
- Added pagination metadata to the SSO quickstart and social login documentation for better navigation.
- Updated the caption in the social login documentation to reflect the use of social connectors.
- Changed the provider in the authorization URL example from 'microsoft' to 'google' for accuracy.